### PR TITLE
Closes #6. Before assigning a role, check that the user is not deleted.

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -33,10 +33,14 @@ define('LOCAL_COHORTROLE_ROLE_COMPONENT', 'local_cohortrole');
  * @return void
  */
 function local_cohortrole_role_assign($cohortid, $roleid, array $userids) {
-    $context = context_system::instance();
+    global $DB;
 
+    $context = context_system::instance();
+    $deleted = $DB->get_records_menu('user', array('deleted' => 1));
     foreach ($userids as $userid) {
-        role_assign($roleid, $userid, $context->id, LOCAL_COHORTROLE_ROLE_COMPONENT, $cohortid);
+        if (!isset($deleted[$userid])) {
+            role_assign($roleid, $userid, $context->id, LOCAL_COHORTROLE_ROLE_COMPONENT, $cohortid);
+        }
     }
 }
 

--- a/locallib.php
+++ b/locallib.php
@@ -36,10 +36,13 @@ function local_cohortrole_role_assign($cohortid, $roleid, array $userids) {
     global $DB;
 
     $context = context_system::instance();
-    $deleted = $DB->get_records_menu('user', array('deleted' => 1));
     foreach ($userids as $userid) {
-        if (!isset($deleted[$userid])) {
+        $user = core_user::get_user($userid, '*', MUST_EXIST);
+        try {
+            $active = core_user::require_active_user($user);
             role_assign($roleid, $userid, $context->id, LOCAL_COHORTROLE_ROLE_COMPONENT, $cohortid);
+        } catch (Exception $e) {
+            // Exception is caught. Do nothing.
         }
     }
 }

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_cohortrole';
-$plugin->release   = '3.3.1';
+$plugin->release   = '3.3';
 $plugin->version   = 2020110900;
 $plugin->requires  = 2018051703; // Moodle 3.5.3 onwards.
 $plugin->maturity  = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_cohortrole';
-$plugin->release   = '3.3';
+$plugin->release   = '3.3.1';
 $plugin->version   = 2020110900;
 $plugin->requires  = 2018051703; // Moodle 3.5.3 onwards.
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Before assigning a system role to the user, this improvement first checks that the user is not deleted. This is to prevent unnecessary hangups in the process.