### PR TITLE
Assign role for unconfirmed, suspended and nologin users, fixes #15 #…

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -36,12 +36,16 @@ function local_cohortrole_role_assign($cohortid, $roleid, array $userids) {
     $context = context_system::instance();
 
     foreach ($userids as $userid) {
-        try {
-            $user = core_user::get_user($userid, '*', MUST_EXIST);
-            core_user::require_active_user($user);
+        $user = core_user::get_user($userid, '*', MUST_EXIST);
+
+        if (
+            core_user::is_real_user($user->id)
+            &&
+            empty($user->deleted)
+            &&
+            !isguestuser($user)
+        ) {
             role_assign($roleid, $user->id, $context->id, LOCAL_COHORTROLE_ROLE_COMPONENT, $cohortid);
-        } catch (Exception $e) { // phpcs:ignore
-            // Exception is caught. Do nothing.
         }
     }
 }


### PR DESCRIPTION
In commit 13085f55e73d2ed6cf715bd1b8a0092acab47397 the stated aim was to stop assigning roles for deleted users, but by using core_user::require_active_user this also excluded suspended or unconfirmed users.
In addition, it swallowed the exception making it pretty hard to debug...


This fixes issues #15 #11 #10