### PR TITLE
Add support for category-level cohorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,168 @@
-# Cohort role synchronization [![Build Status](https://github.com/paulholden/moodle-local_cohortrole/workflows/moodle-plugin-ci/badge.svg)](https://github.com/paulholden/moodle-local_cohortrole/actions)
+# Cohort Role Synchronization - Extended for Category Cohorts
+
+[![Moodle Plugin](https://img.shields.io/badge/Moodle%20Plugin-local__cohortrole-blue)](https://moodle.org/plugins/local_cohortrole)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Moodle 4.1+](https://img.shields.io/badge/Moodle-4.1%2B-orange)](https://moodle.org)
+
+A Moodle local plugin to synchronize cohorts with system roles. **This fork extends the original plugin to support cohorts at the course category level**, not just system-level cohorts.
+
+## About This Fork
+
+This is a fork of [paulholden/moodle-local_cohortrole](https://github.com/paulholden/moodle-local_cohortrole).
+
+### What's New in This Fork
+
+The original plugin only supported cohorts defined at the **system level**. This fork adds:
+
+- **Category-level cohort support** - Select cohorts from any course category
+- **Grouped dropdown** - Cohorts are displayed grouped by context (System / Category)
+- **Category path display** - Nested categories show full path (e.g., "Parent / Child / Subcategory")
+- **Custom role support** - Improved role detection including custom roles
+- **Context column** - Overview table shows where each cohort is located
+- **German translation** - Full German language pack included
+
+### Important Design Decision
+
+**Roles are always assigned in the system context**, regardless of where the cohort is located. This ensures that system-level capabilities (like `moodle/site:uploadusers` or `moodle/user:create`) work correctly.
 
 ## Requirements
 
-- Moodle 4.1 or later.
+- Moodle 4.1 or later
 
 ## Installation
 
-Copy the cohortrole folder into your Moodle /local directory and visit your admin notification page to complete the installation.
-
-Once installed, you should see a new option in your site administration:
-
-> Users -> Accounts -> Cohort role synchronization
+1. Download the plugin
+2. Extract to your Moodle `/local/cohortrole` directory
+3. Visit Site Administration → Notifications to complete the installation
+4. Clear caches
 
 ## Usage
 
-1. Create system-level cohort(s).
-2. Create system-level assignable role(s) - optional, you can also use existing roles.
-3. Visit Cohort role synchronization page.
-4. Create new link between cohort and role.
-5. Users will automatically be (un)assigned to the role according to their membership of selected cohort.
+Once installed, you will find a new option in Site Administration:
 
-## Author
+**Users → Accounts → Cohort role synchronization**
 
-Paul Holden (paulh@moodle.com)
+### Setup Steps
 
-- Updates: https://moodle.org/plugins/view.php?plugin=local_cohortrole
-- Latest code: https://github.com/paulholden/moodle-local_cohortrole
+1. Create cohorts at system level OR in course categories
+2. Create or use existing roles that are assignable at system level
+3. Visit the Cohort role synchronization page
+4. Create a new synchronization by selecting:
+   - A cohort (grouped by System / Category)
+   - A role to assign
+5. Save changes
+
+Users will automatically be assigned/unassigned the role based on their cohort membership.
+
+## Screenshots
+
+### Cohort Selection (Grouped by Context)
+
+The cohort dropdown now shows cohorts grouped by their context:
+
+```
+┌─────────────────────────────────┐
+│ ▼ Cohort                        │
+├─────────────────────────────────┤
+│ System                          │
+│   ├─ All Staff                  │
+│   └─ Administrators             │
+│ Category: Faculty of Science    │
+│   ├─ Science Teachers           │
+│   └─ Lab Assistants             │
+│ Category: Faculty of Arts       │
+│   └─ Arts Department            │
+└─────────────────────────────────┘
+```
+
+### Overview Table with Context Column
+
+| Cohort | Cohort Context | Role | Modified |
+|--------|---------------|------|----------|
+| Science Teachers | Category: Faculty of Science | Manager | 25 Nov 2025 |
+| All Staff | System | Custom Role | 24 Nov 2025 |
+
+## Changes from Original
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `locallib.php` | Role assignment always in system context |
+| `classes/form/edit.php` | Load cohorts from system + categories, grouped display |
+| `classes/persistent.php` | Extended validation for category cohorts |
+| `classes/observers.php` | Event handlers respond to category-level events |
+| `classes/output/summary_table.php` | New "Cohort context" column |
+| `lang/en/local_cohortrole.php` | New language strings |
+| `lang/de/local_cohortrole.php` | German translation (new) |
+| `version.php` | Version updated to 2025112501 |
+
+### New Language Strings
+
+| Key | English | German |
+|-----|---------|--------|
+| `categorycontext` | Category: {$a} | Kategorie: {$a} |
+| `cohortcontext` | Cohort context | Kontext der Gruppe |
+| `systemcontext` | System | System |
+
+## Technical Details
+
+### How It Works
+
+1. **Cohort Selection**: The form queries all cohorts from:
+   - System context (`context_system`)
+   - All course category contexts (`context_coursecat`)
+
+2. **Role Assignment**: When a user is added to a cohort:
+   - The plugin detects the cohort membership change via event observers
+   - The role is assigned in the **system context** (always)
+   - This ensures system-wide capabilities work correctly
+
+3. **Role Removal**: When a user is removed from a cohort:
+   - The corresponding role assignment is removed from the system context
+
+### Event Observers
+
+The plugin listens for these events (now in both system and category contexts):
+
+- `\core\event\cohort_deleted`
+- `\core\event\cohort_member_added`
+- `\core\event\cohort_member_removed`
+- `\core\event\role_deleted`
+
+## Compatibility
+
+- **Moodle**: 4.1 and later
+- **PHP**: 7.4 and later (as required by Moodle)
+- **Database**: No schema changes required (fully compatible with original)
+
+## Credits
+
+- **Original Author**: Paul Holden (paulh@moodle.com)
+- **Original Plugin**: [moodle.org/plugins/local_cohortrole](https://moodle.org/plugins/local_cohortrole)
+
+## License
+
+This plugin is licensed under the [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.html).
+
+## Changelog
+
+### Version 5.1 (2025112501) - This Fork
+
+- Added support for category-level cohorts
+- Cohorts displayed in grouped dropdown by context
+- New "Cohort context" column in overview table
+- Added German translation
+- Improved custom role detection
+- Role assignment always in system context
+
+### Previous Versions
+
+See the [original repository](https://github.com/paulholden/moodle-local_cohortrole) for the complete changelog.
+
+## Support
+
+- **Issues**: Please report issues on GitHub
+- **Original Plugin Support**: [Moodle Plugin Directory](https://moodle.org/plugins/local_cohortrole)
+
+---

--- a/classes/form/edit.php
+++ b/classes/form/edit.php
@@ -14,14 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * ...
+ * @copyright  2013 Paul Holden <paulh@moodle.com>
+ * @copyright  2025 Andrea Jüttner
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 namespace local_cohortrole\form;
 
 defined('MOODLE_INTERNAL') || die();
 
 use local_cohortrole\persistent;
-use stdClass;
 
-global $CFG;
 require_once($CFG->dirroot . '/cohort/lib.php');
 
 /**
@@ -32,16 +37,24 @@ require_once($CFG->dirroot . '/cohort/lib.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class edit extends \core\form\persistent {
+
     /** @var string Persistent class name. */
     protected static $persistentclass = persistent::class;
 
     /**
      * Form definition
+     *
+     * @return void
      */
     protected function definition() {
         $mform = $this->_form;
 
-        $mform->addElement('select', 'cohortid', get_string('cohort', 'local_cohortrole'), self::get_cohorts());
+        $cohorts = self::get_cohorts();
+        if (!empty($cohorts)) {
+            $mform->addElement('selectgroups', 'cohortid', get_string('cohort', 'local_cohortrole'), $cohorts);
+        } else {
+            $mform->addElement('select', 'cohortid', get_string('cohort', 'local_cohortrole'), []);
+        }
         $mform->addRule('cohortid', get_string('required'), 'required', null, 'client');
         $mform->setType('cohortid', PARAM_INT);
         $mform->addHelpButton('cohortid', 'cohort', 'local_cohortrole');
@@ -63,12 +76,9 @@ class edit extends \core\form\persistent {
      * @return array
      */
     public function extra_validation($data, $files, array &$errors) {
-        $exists = $this->get_persistent()->record_exists_select(
-            'cohortid = :cohortid AND roleid = :roleid',
-            ['cohortid' => $data->cohortid, 'roleid' => $data->roleid],
-        );
+        if ($this->get_persistent()->record_exists_select('cohortid = :cohortid AND roleid = :roleid',
+                ['cohortid' => $data->cohortid, 'roleid' => $data->roleid])) {
 
-        if ($exists) {
             $errors['cohortid'] = get_string('errorexists', 'local_cohortrole');
         }
 
@@ -76,31 +86,126 @@ class edit extends \core\form\persistent {
     }
 
     /**
-     * Get cohorts that are defined in the system context
+     * Get cohorts from system context and all category contexts, grouped by context
      *
-     * @return array
+     * @return array Grouped array for selectgroups element
      */
     protected static function get_cohorts() {
-        $cohorts = cohort_get_cohorts(\context_system::instance()->id, null, null);
+        global $DB;
 
         $result = [];
-        foreach ($cohorts['cohorts'] as $cohort) {
-            $result[$cohort->id] = $cohort->name;
+
+        // Get system context cohorts.
+        $systemcontext = \context_system::instance();
+        $systemcohorts = cohort_get_cohorts($systemcontext->id, 0, 1000);
+
+        if (!empty($systemcohorts['cohorts'])) {
+            $systemgroup = [];
+            foreach ($systemcohorts['cohorts'] as $cohort) {
+                $systemgroup[$cohort->id] = format_string($cohort->name, true, ['context' => $systemcontext]);
+            }
+            if (!empty($systemgroup)) {
+                \core_collator::asort($systemgroup, \core_collator::SORT_STRING);
+                $result[get_string('systemcontext', 'local_cohortrole')] = $systemgroup;
+            }
+        }
+
+        // Get all course categories and their cohorts.
+        $categories = $DB->get_records('course_categories', null, 'sortorder ASC', 'id, name, parent');
+        foreach ($categories as $category) {
+            $categorycontext = \context_coursecat::instance($category->id, IGNORE_MISSING);
+            if (!$categorycontext) {
+                continue;
+            }
+            
+            $categorycohorts = cohort_get_cohorts($categorycontext->id, 0, 1000);
+
+            if (!empty($categorycohorts['cohorts'])) {
+                $categorygroup = [];
+                foreach ($categorycohorts['cohorts'] as $cohort) {
+                    $categorygroup[$cohort->id] = format_string($cohort->name, true, ['context' => $categorycontext]);
+                }
+                if (!empty($categorygroup)) {
+                    \core_collator::asort($categorygroup, \core_collator::SORT_STRING);
+                    // Build category path for better identification.
+                    $categoryname = self::get_category_path($category);
+                    $result[get_string('categorycontext', 'local_cohortrole', $categoryname)] = $categorygroup;
+                }
+            }
         }
 
         return $result;
     }
 
     /**
+     * Get the full path of a category (for nested categories)
+     *
+     * @param stdClass $category The category object
+     * @return string The category path
+     */
+    protected static function get_category_path($category) {
+        global $DB;
+
+        $path = format_string($category->name);
+
+        // Get parent categories if any.
+        if (!empty($category->parent) && $category->parent > 0) {
+            $parents = [];
+            $parentid = $category->parent;
+            $maxdepth = 10; // Prevent infinite loops.
+            $depth = 0;
+            
+            while ($parentid > 0 && $depth < $maxdepth) {
+                $parent = $DB->get_record('course_categories', ['id' => $parentid], 'id, name, parent');
+                if ($parent) {
+                    array_unshift($parents, format_string($parent->name));
+                    $parentid = $parent->parent;
+                } else {
+                    break;
+                }
+                $depth++;
+            }
+            if (!empty($parents)) {
+                $path = implode(' / ', $parents) . ' / ' . $path;
+            }
+        }
+
+        return $path;
+    }
+
+    /**
      * Get roles that are assignable in the system context
+     *
+     * Uses get_all_roles() and filters by context level to include custom roles.
      *
      * @return array
      */
     protected static function get_roles() {
-        $roles = get_assignable_roles(\context_system::instance(), ROLENAME_ALIAS);
+        global $DB;
 
-        \core_collator::asort($roles, \core_collator::SORT_STRING);
+        $systemcontext = \context_system::instance();
+        
+        // First try get_assignable_roles - this respects permissions.
+        $result = get_assignable_roles($systemcontext, ROLENAME_ALIAS);
+        
+        // Additionally, get all roles that have CONTEXT_SYSTEM in their allowed context levels.
+        // This ensures custom roles are included even if role_allow_assign is not configured.
+        $sql = "SELECT DISTINCT r.id, r.shortname, r.name, r.sortorder
+                FROM {role} r
+                INNER JOIN {role_context_levels} rcl ON rcl.roleid = r.id
+                WHERE rcl.contextlevel = ?
+                ORDER BY r.sortorder";
+        
+        $roles = $DB->get_records_sql($sql, [CONTEXT_SYSTEM]);
+        
+        foreach ($roles as $role) {
+            if (!isset($result[$role->id])) {
+                $result[$role->id] = role_get_name($role, $systemcontext, ROLENAME_ALIAS);
+            }
+        }
 
-        return $roles;
+        \core_collator::asort($result, \core_collator::SORT_STRING);
+
+        return $result;
     }
 }

--- a/classes/observers.php
+++ b/classes/observers.php
@@ -14,6 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * ...
+ * @copyright  2013 Paul Holden <paulh@moodle.com>
+ * @copyright  2025 Andrea Jüttner
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 namespace local_cohortrole;
 
 defined('MOODLE_INTERNAL') || die();
@@ -28,6 +35,17 @@ require_once($CFG->dirroot . '/local/cohortrole/locallib.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class observers {
+
+    /**
+     * Check if the event context level is valid for cohort role synchronization
+     *
+     * @param int $contextlevel The context level to check
+     * @return bool True if the context level is system or category
+     */
+    protected static function is_valid_context_level($contextlevel) {
+        return ($contextlevel == CONTEXT_SYSTEM || $contextlevel == CONTEXT_COURSECAT);
+    }
+
     /**
      * Cohort deleted
      *
@@ -35,7 +53,7 @@ class observers {
      * @return void
      */
     public static function cohort_deleted(\core\event\cohort_deleted $event) {
-        if ($event->contextlevel == CONTEXT_SYSTEM) {
+        if (self::is_valid_context_level($event->contextlevel)) {
             $cohort = $event->get_record_snapshot('cohort', $event->objectid);
 
             $instances = persistent::get_records(['cohortid' => $cohort->id]);
@@ -56,7 +74,7 @@ class observers {
      * @return void
      */
     public static function cohort_member_added(\core\event\cohort_member_added $event) {
-        if ($event->contextlevel == CONTEXT_SYSTEM) {
+        if (self::is_valid_context_level($event->contextlevel)) {
             $cohort = $event->get_record_snapshot('cohort', $event->objectid);
 
             $instances = persistent::get_records(['cohortid' => $cohort->id]);
@@ -77,7 +95,7 @@ class observers {
      * @return void
      */
     public static function cohort_member_removed(\core\event\cohort_member_removed $event) {
-        if ($event->contextlevel == CONTEXT_SYSTEM) {
+        if (self::is_valid_context_level($event->contextlevel)) {
             $cohort = $event->get_record_snapshot('cohort', $event->objectid);
 
             $instances = persistent::get_records(['cohortid' => $cohort->id]);

--- a/lang/de/local_cohortrole.php
+++ b/lang/de/local_cohortrole.php
@@ -1,0 +1,53 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @copyright  2025 Andrea Jüttner
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Plugin language strings (German)
+ *
+ * @package    local_cohortrole
+ * @copyright  2013 Paul Holden <paulh@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$string['categorycontext'] = 'Kategorie: {$a}';
+$string['cohort'] = 'Globale Gruppe';
+$string['cohort_help'] = 'Liste der globalen Gruppen auf Systemebene oder in Kursbereichen. Die Rolle wird immer im Systemkontext zugewiesen.';
+$string['cohortcontext'] = 'Kontext der Gruppe';
+$string['deleteconfirm'] = 'Möchten Sie diese Synchronisation wirklich löschen?';
+$string['errorexists'] = 'Synchronisation bereits definiert';
+$string['eventdefinitioncreated'] = 'Globale Gruppen-Rollensynchronisation erstellt';
+$string['eventdefinitiondeleted'] = 'Globale Gruppen-Rollensynchronisation gelöscht';
+$string['heading_add'] = 'Neue Synchronisation definieren';
+$string['heading_delete'] = 'Definierte Synchronisation löschen';
+$string['heading_index'] = 'Aktuell definierte Synchronisationen';
+$string['notificationcreated'] = 'Neue Synchronisation erstellt';
+$string['notificationdeleted'] = 'Synchronisation gelöscht';
+$string['pluginname'] = 'Globale Gruppen-Rollensynchronisation';
+$string['privacy:metadata:cohortrole'] = 'Enthält Synchronisationsdefinitionen von globalen Gruppen zu Rollen';
+$string['privacy:metadata:cohortrole:cohortid'] = 'Die ID der globalen Gruppe';
+$string['privacy:metadata:cohortrole:roleid'] = 'Die ID der Rolle';
+$string['privacy:metadata:cohortrole:timecreated'] = 'Der Zeitstempel der Erstellung der Definition';
+$string['privacy:metadata:cohortrole:usermodified'] = 'Die ID des Nutzers, der die Definition erstellt hat';
+$string['role'] = 'Rolle';
+$string['role_help'] = 'Liste der zuweisbaren Rollen. Die Rolle wird immer im Systemkontext zugewiesen, unabhängig davon, wo sich die globale Gruppe befindet.';
+$string['systemcontext'] = 'System';

--- a/lang/en/local_cohortrole.php
+++ b/lang/en/local_cohortrole.php
@@ -19,13 +19,16 @@
  *
  * @package    local_cohortrole
  * @copyright  2013 Paul Holden <paulh@moodle.com>
+ * @copyright  2025 Andrea Juettner
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
+$string['categorycontext'] = 'Category: {$a}';
 $string['cohort'] = 'Cohort';
-$string['cohort_help'] = 'List of cohorts that exist in the system context';
+$string['cohort_help'] = 'List of cohorts that exist in the system context or in course category contexts. The role will always be assigned in the system context.';
+$string['cohortcontext'] = 'Cohort context';
 $string['deleteconfirm'] = 'Are you sure you want to delete this synchronization?';
 $string['errorexists'] = 'Synchronization already defined';
 $string['eventdefinitioncreated'] = 'Cohort role synchronization created';
@@ -42,4 +45,5 @@ $string['privacy:metadata:cohortrole:roleid'] = 'The ID of the role';
 $string['privacy:metadata:cohortrole:timecreated'] = 'The timestamp the definition was created';
 $string['privacy:metadata:cohortrole:usermodified'] = 'The ID of the user who created the definition';
 $string['role'] = 'Role';
-$string['role_help'] = 'List of assignable roles in the system context';
+$string['role_help'] = 'List of assignable roles. The role will always be assigned in the system context, regardless of where the cohort is located.';
+$string['systemcontext'] = 'System';

--- a/locallib.php
+++ b/locallib.php
@@ -19,6 +19,7 @@
  *
  * @package    local_cohortrole
  * @copyright  2013 Paul Holden <paulh@moodle.com>
+ * @copyright  2025 Andrea Juettner
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -27,12 +28,17 @@ define('LOCAL_COHORTROLE_ROLE_COMPONENT', 'local_cohortrole');
 /**
  * Assign users to a role; using local role component
  *
+ * Role assignments are ALWAYS made in the SYSTEM context, regardless of
+ * which context the cohort belongs to. This ensures that system-level
+ * capabilities work correctly.
+ *
  * @param integer $cohortid the id of a cohort
  * @param integer $roleid the id of a role
  * @param array $userids an array of user ids to assign
  * @return void
  */
 function local_cohortrole_role_assign($cohortid, $roleid, array $userids) {
+    // Always assign roles in the SYSTEM context.
     $context = context_system::instance();
 
     foreach ($userids as $userid) {
@@ -59,6 +65,7 @@ function local_cohortrole_role_assign($cohortid, $roleid, array $userids) {
  * @return void
  */
 function local_cohortrole_role_unassign($cohortid, $roleid, array $userids) {
+    // Always unassign from SYSTEM context.
     $context = context_system::instance();
 
     foreach ($userids as $userid) {
@@ -90,7 +97,10 @@ function local_cohortrole_synchronize($cohortid, $roleid) {
  */
 function local_cohortrole_unsynchronize($cohortid, $roleid = null) {
     $params = [
-        'contextid' => context_system::instance()->id, 'component' => LOCAL_COHORTROLE_ROLE_COMPONENT, 'itemid' => $cohortid, ];
+        'contextid' => context_system::instance()->id,
+        'component' => LOCAL_COHORTROLE_ROLE_COMPONENT,
+        'itemid' => $cohortid,
+    ];
 
     if ($roleid === null) {
         $roleids = local_cohortrole_get_cohort_roles($cohortid);


### PR DESCRIPTION
Hi Paul,

This PR adds support for category-level cohorts, which has been requested by the community (see plugin comments on moodle.org).

## Changes

- **Category cohort support**: Cohorts from course categories are now selectable, not just system-level cohorts
- **Grouped dropdown**: Cohorts are displayed grouped by context (System / Category name)
- **Category path display**: Nested categories show full path (e.g., "Parent / Child")
- **New "Cohort context" column**: Overview table shows where each cohort is located
- **Improved role detection**: Better support for custom roles
- **German translation**: Added `lang/de/local_cohortrole.php`

## Important Design Decision

Roles are **always assigned in the system context**, regardless of where the cohort is located. This ensures that system-level capabilities (like `moodle/site:uploadusers`) work correctly.

## Modified Files

- `classes/form/edit.php` - Load cohorts from system + categories
- `classes/persistent.php` - Extended validation for category cohorts
- `classes/observers.php` - Event handlers for category-level events
- `classes/output/summary_table.php` - New context column
- `lang/en/local_cohortrole.php` - New language strings
- `lang/de/local_cohortrole.php` - German translation (new)
- `version.php` - Version 2025112501

## Testing

Tested on Moodle 4.x with:
- System-level cohorts ✓
- Category-level cohorts ✓
- Custom roles ✓
- Standard roles (Manager, Course Creator) ✓

Let me know if you'd like any changes!